### PR TITLE
docs(seatbelt): fix SBPL semantics comment (last-match, not most-specific-match)

### DIFF
--- a/lot/lot/src/macos/seatbelt.rs
+++ b/lot/lot/src/macos/seatbelt.rs
@@ -216,8 +216,8 @@ pub fn generate_profile(
         append_sbpl_rule(&mut profile, "allow", "file-read*", "subpath", path)?;
     }
 
-    // Deny rules override grants above. SBPL uses most-specific-match-wins
-    // semantics, so these must appear after the allow rules for the denied subtrees.
+    // Deny rules override grants above. SBPL uses last-match-wins semantics,
+    // so these must appear after the allow rules for the denied subtrees.
     for path in policy.deny_paths() {
         append_sbpl_rule(&mut profile, "deny", "file-read*", "subpath", path)?;
         // file-read-metadata is a separate SBPL operation not covered by file-read*


### PR DESCRIPTION
## Summary

\`lot/lot/src/macos/seatbelt.rs:219\` claimed SBPL uses 'most-specific-match-wins' semantics, but SBPL actually evaluates rules in file order with **last-match-wins** semantics. The deny rules appended after the allow rules work correctly *because* of last-match, not because of specificity — so this is a comment-only fix to keep the mental model accurate for future maintainers.

Closes #255

## Testing

Comment-only change; no behavior altered.