### PR TITLE
docs(SandboxCommand.env): clarify Unix vs Windows env-essentials behavior

### DIFF
--- a/lot/lot/src/command.rs
+++ b/lot/lot/src/command.rs
@@ -20,8 +20,11 @@ pub enum SandboxStdio {
 pub struct SandboxCommand {
     pub(crate) program: OsString,
     pub(crate) args: Vec<OsString>,
-    /// Additional env vars. Platform essentials are always included.
-    /// To forward a parent var, read it from `std::env` and pass it here.
+    /// Additional env vars.
+    /// On Unix, a default `PATH` is always included even when this vec is empty.
+    /// On Windows, an empty vec causes the child to inherit the parent process's
+    /// full environment (per Win32 `CreateProcessW` with a NULL `lpEnvironment`).
+    /// To forward a parent var on Unix, read it from `std::env` and pass it here.
     pub(crate) env: Vec<(OsString, OsString)>,
     pub(crate) cwd: Option<PathBuf>,
     pub(crate) stdin: SandboxStdio,


### PR DESCRIPTION
## Summary

Per #254, the \`env\` field doc on \`SandboxCommand\` said 'Platform essentials are always included', which is true on Unix (an explicit \`envp\` with a default \`PATH\` is built when the vec is empty) but misleading on Windows — \`appcontainer.rs\` passes \`NULL\` as \`lpEnvironment\` to \`CreateProcessW\` when the vec is empty, which per Win32 semantics makes the child inherit the **full** parent environment, not a curated minimal set.

Reworded the doc to describe both platforms accurately so maintainers don't get a wrong mental model about environment isolation.

Closes #254

## Testing

Comment-only change; no behavior altered. No other callers rely on the wording.